### PR TITLE
[CHORE] Add ability to internally retry /oauth/token calls.

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,6 +1,6 @@
 const { requestWithRetries, isRequestError, isStatusCodeError } = require('./requestPromiseUtils');
 
-const retryHandler = (err, nextTryCount) => {
+const shouldRetry = (err, nextTryCount) => {
   if (nextTryCount > 5) {
     return false;
   }
@@ -32,7 +32,7 @@ module.exports = (zuoraClient) => {
       json: true,
     };
 
-    const response = await requestWithRetries(options, retryHandler, computeRetryDelay);
+    const response = await requestWithRetries(options, shouldRetry, computeRetryDelay);
     if (!response) {
       throw new Error('ZuoraJS: Auth: Empty Response');
     }

--- a/auth.js
+++ b/auth.js
@@ -1,4 +1,14 @@
-const request = require('request-promise');
+const { requestWithRetries, isRequestError, isStatusCodeError } = require('./requestPromiseUtils');
+
+const retryHandler = (err, nextTryCount) => {
+  if (nextTryCount > 5) {
+    return false;
+  }
+
+  return isRequestError(err) || (isStatusCodeError(err) && (err.statusCode === 403));
+};
+
+const computeRetryDelay = (err, nextTryCount) => (Math.round(Math.random() * 100) + (nextTryCount * 750));
 
 module.exports = (zuoraClient) => {
   let accessToken;
@@ -22,7 +32,10 @@ module.exports = (zuoraClient) => {
       json: true,
     };
 
-    const response = await request(options);
+    const response = await requestWithRetries(options, retryHandler, computeRetryDelay);
+    if (!response) {
+      throw new Error('ZuoraJS: Auth: Empty Response');
+    }
 
     accessToken = response.access_token;
     renewalTime = Date.now() + ((response.expires_in * 1000) - 60000);

--- a/requestPromiseUtils.js
+++ b/requestPromiseUtils.js
@@ -1,13 +1,13 @@
 const requestPromise = require('request-promise');
 const requestPromiseErrors = require('request-promise/errors');
 
-const requestWithRetries = async (requestOptions, retryHandler, computeRetryDelay) => {
+const requestWithRetries = async (requestOptions, shouldRetry, computeRetryDelay) => {
   const makeRequest = async (tryCount) => {
     let response;
     try {
       response = await requestPromise(requestOptions);
     } catch (err) {
-      if (!retryHandler || !retryHandler(err, tryCount)) {
+      if (!shouldRetry || !shouldRetry(err, tryCount)) {
         throw err;
       }
 

--- a/requestPromiseUtils.js
+++ b/requestPromiseUtils.js
@@ -1,0 +1,34 @@
+const requestPromise = require('request-promise');
+const requestPromiseErrors = require('request-promise/errors');
+
+const requestWithRetries = async (requestOptions, retryHandler, computeRetryDelay) => {
+  const makeRequest = async (tryCount) => {
+    let response;
+    try {
+      response = await requestPromise(requestOptions);
+    } catch (err) {
+      if (!retryHandler || !retryHandler(err, tryCount)) {
+        throw err;
+      }
+
+      const nextTryCount = tryCount + 1;
+      const retryDelay = await ((computeRetryDelay && computeRetryDelay(err, nextTryCount)) || 1000);
+      await new Promise((resolve) => setTimeout(resolve, retryDelay));
+
+      response = makeRequest(nextTryCount);
+    }
+
+    return response;
+  };
+
+  return makeRequest(1);
+};
+
+const isRequestError = (err) => (err instanceof requestPromiseErrors.RequestError);
+const isStatusCodeError = (err) => (err instanceof requestPromiseErrors.StatusCodeError);
+
+module.exports = {
+  requestWithRetries,
+  isRequestError,
+  isStatusCodeError,
+};


### PR DESCRIPTION
This change set will retry calls to `/oauth/token` for certain known failure conditions.

We have logs of the failure:
```pre
Nov 07 16:02:42 coschedule app/web.4: (4) ERROR: POST /billing/v4/checkout/preview/read_only: StatusCodeError: 403 - {"timestamp":"2018-11-07T22:02:42.107+0000","status":403,"error":"Forbidden","path":"/oauth/token"} 
Nov 11 15:02:38 coschedule app/web.4:  (4) ERROR: Users.afterCreateUser: Organizations.createOrganizationAndInitialCalendar: StatusCodeError: 403 - {"timestamp":"2018-11-11T21:02:37.852+0000","status":403,"error":"Forbidden","path":"/oauth/token"} 
```